### PR TITLE
NPC Create & Reply

### DIFF
--- a/src/commands/npc/npcCreate.js
+++ b/src/commands/npc/npcCreate.js
@@ -1,0 +1,43 @@
+// using modals and webhooks to create a new NPC for discord messaging
+const { ActionRowBuilder, ModalBuilder, TextInputBuilder, TextInputStyle, SlashCommandBuilder } = require('discord.js');
+
+module.exports = {
+    cooldown: 5,
+    data: new SlashCommandBuilder()
+        .setName('createnpc')
+        .setDescription('Creates a new NPC for the server'),
+
+    async execute(interaction) {
+        // TODO configure required role
+
+        // TODO create a modal to get the NPC name and description
+        const modal = new ModalBuilder()
+            .setCustomId('createNpcModal')
+            .setTitle('Create a new NPC');
+
+        const nameInput = new TextInputBuilder()
+            .setCustomId('npcName')
+            .setLabel('NPC Name')
+            .setStyle(TextInputStyle.Short)
+            .setRequired(true);
+
+        const imageInput = new TextInputBuilder()
+            .setCustomId('npcImage')
+            .setLabel('NPC Image URL')
+            .setStyle(TextInputStyle.Short)
+            .setRequired(true);
+
+        const descriptionInput = new TextInputBuilder()
+            .setCustomId('npcDescription')
+            .setLabel('NPC Description')
+            .setStyle(TextInputStyle.Paragraph)
+            .setRequired(false);
+
+        const row1 = new ActionRowBuilder().addComponents(nameInput);
+        const row2 = new ActionRowBuilder().addComponents(imageInput);
+        const row3 = new ActionRowBuilder().addComponents(descriptionInput);
+
+        modal.addComponents(row1, row2, row3);
+        await interaction.showModal(modal);
+    },
+};

--- a/src/commands/npc/npcReply.js
+++ b/src/commands/npc/npcReply.js
@@ -1,6 +1,4 @@
-const { ContextMenuCommandBuilder, ApplicationCommandType, ModalBuilder,
-    ActionRowBuilder, TextInputBuilder, TextInputStyle, SlashCommandBuilder,
-    MessageFlags } = require('discord.js');
+const { SlashCommandBuilder, MessageFlags, ContainerBuilder, ComponentType } = require('discord.js');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -9,94 +7,179 @@ module.exports = {
         .addStringOption(option =>
             option.setName('npcname')
                 .setDescription('Enter the name of the NPC you want to reply as')
-                .setRequired(true))
-        .addStringOption(option =>
-            option.setName('message')
-                .setDescription('Enter the message you want to reply')
-                .setRequired(true))
+                .setRequired(true)
+                .setAutocomplete(true))
         .addStringOption(option =>
             option.setName('messagelink')
-                .setDescription('Paste the id of a message here to reply it')
+                .setDescription('Paste the id of a message here to reply to')
                 .setRequired(false)),
+
     async execute(interaction) {
-
-        await interaction.reply({ content: 'Sending...', flags: MessageFlags.Ephemeral });
-
-        const channel = interaction.channel;
+        const npcId = interaction.options.getString('npcname');
         const messageId = interaction.options.getString('messagelink');
-        const message = await channel.messages.fetch(messageId)
-            .catch(console.error);
+        const base_channel = interaction.channel;
 
-        // why are we not replying to the message?
-        await message.reply(`${interaction.options.getString('npcname')}: ${interaction.options.getString('message')}`)
-        .catch(console.error);
-        await interaction.editReply({ content: 'Sent!', flags: MessageFlags.Ephemeral });
+        // validate inputs
+        let webhook;
+        try {
+            // Fetch the webhooks for the channel
+            const webhooks = await base_channel.fetchWebhooks();
+            // Find the webhook with the matching name
+            webhook = webhooks.find(wh => wh.id === npcId);
+            if (!webhook) {
+                console.error(`No webhook found for NPC: ${npcId}`);
+                await interaction.reply({ content: `No webhook found for NPC: ${npcId}`, flags: MessageFlags.Ephemeral });
+                return;
+            }
+        }
+        catch (err) {
+            console.error('Error fetching webhooks:', err);
+            await interaction.reply({ content: 'Error fetching webhooks. Please try again later.', flags: MessageFlags.Ephemeral });
+            return;
+        }
+
+        let targetMessage;
+        if (messageId) {
+            try {
+                // Fetch the message to reply to
+                targetMessage = await base_channel.messages.fetch(messageId);
+            }
+            catch (err) {
+                console.error('Error fetching message:', err);
+                await interaction.reply({ content: 'Could not find the message to reply to. Please check the message ID.', flags: MessageFlags.Ephemeral });
+                return;
+            }
+        }
+
+        // Try to DM the user
+        let dmChannel;
+        try {
+            dmChannel = await interaction.user.createDM();
+        }
+        catch (err) {
+            console.error('Could not create DM channel:', err);
+            await interaction.reply({ content: 'Could not send you a DM! Please check your server privacy settings to allow Direct Messages.', flags: MessageFlags.Ephemeral });
+            return;
+        }
+
+        console.log(`Validated inputs: Webhook ID: ${npcId}, Message ID: ${messageId}, DM Channel: ${dmChannel.id}`);
+
+        // create a container builder 
+        const messages = [];
+        const container = new ContainerBuilder({
+            components: [
+                {
+                    content: '-# Type messages in this channel to add to the reply',
+                    type: ComponentType.TextDisplay,
+                },
+                {
+                    type: ComponentType.ActionRow,
+                    components: [
+                        {
+                            type: ComponentType.Button,
+                            custom_id: 'finish',
+                            label: 'Finish',
+                            style: 1, // Primary style
+                        },
+                        {
+                            type: ComponentType.Button,
+                            custom_id: 'cancel',
+                            label: 'Cancel',
+                            style: 2, // Secondary style
+                        },
+                    ],
+                },
+            ],
+        });
+
+        // send the initial container
+        const containerMsg = await dmChannel.send({ components: [container], flags: MessageFlags.IsComponentsV2 })
+            .catch(err => {
+                console.error('Error sending container message:', err);
+                return;
+            });
+
+        // send a message in the original channel to notify the user
+        await interaction.reply({ content: `Check your DMs to reply as ${webhook.name}!`, flags: MessageFlags.Ephemeral });
+
+        // set up collectors for messages and button interactions
+        const messageFilter = m => !m.content.startsWith('cancel') || !m.content.startsWith('finish');
+        const messageCollector = dmChannel.createMessageCollector({
+            filter: messageFilter,
+            idle: 120_000, // 2 minute idle time
+            time: 300_000, // 5 minutes total time
+        });
+
+        const buttonCollector = containerMsg.createMessageComponentCollector({
+            componentType: ComponentType.Button,
+            idle: 120_000, // 2 minute idle time
+            time: 300_000, // 5 minutes total time
+        });
+
+        messageCollector.on('collect', async (message) => {
+            messages.push(message.content);
+            container.addTextDisplayComponents({
+                content: `${message.content}`,
+                type: ComponentType.TextDisplay,
+            });
+            await containerMsg.edit({ components: [container], flags: MessageFlags.IsComponentsV2 });
+
+            console.log(`Collected message: ${message.content}`);
+        });
+
+        messageCollector.on('dispose', (message) => {
+            if (message.content.toLowerCase().startsWith('cancel') || message.content.toLowerCase().startsWith('finish')) {
+                messageCollector.stop('cancelled');
+                console.log('Message collection cancelled by user.');
+                return;
+            }
+            console.error('Message was disposed');
+            return;
+        });
+
+        messageCollector.on('end', async (collected) => {
+            await dmChannel.send(`Message collection ended. Collected ${collected.size} messages`);
+        });
+
+        // at some point, this will need additional confirmation
+        buttonCollector.on('collect', async (buttonInteraction) => {
+            if (buttonInteraction.customId === 'finish') {
+                // send the reply using the webhook
+                try {
+                    await webhook.send({
+                        content: messages.join('\n'),
+                        allowedMentions: { parse: [] }, // prevent mentions
+                        flags: MessageFlags.SuppressEmbeds,
+                    });
+                    messageCollector.stop('finished');
+                    await buttonInteraction.reply({ content: 'Reply sent successfully!', flags: MessageFlags.Ephemeral });
+                }
+                catch (err) {
+                    console.error('Error sending webhook message:', err);
+                    await buttonInteraction.reply({ content: 'Failed to send reply.', flags: MessageFlags.Ephemeral });
+                }
+            }
+            else if (buttonInteraction.customId === 'cancel') {
+                await buttonInteraction.reply({ content: 'Reply cancelled.', flags: MessageFlags.Ephemeral });
+                messageCollector.stop('cancelled');
+            }
+        });
+
+    },
+    async autocomplete(interaction) {
+
+        // note: the number of choices is limited to 25
+        const focusedValue = await interaction.options.getFocused();
+        // this returns a collection (extension of Map)
+        const webhookMap = await interaction.channel.fetchWebhooks()
+            .catch(err => {
+                console.error('Error fetching webhooks:', err);
+                return [];
+            });
+
+        // const filtered = npcNames.filter(choice => choice.startsWith(focusedValue));
+        await interaction.respond(
+            webhookMap.map(wh => ({ name: wh.name, value: wh.id })),
+        );
     },
 };
-
-const contextCommand = new ContextMenuCommandBuilder()
-        .setName('npcReply')
-        .setType(ApplicationCommandType.Message);
-        // .setDefaultMemberPermissions(PermissionFlagsBits.SendMessages)
-        // .setContexts(0) // 0 = guild, 1 = dm bot, 2 = private channel
-        // .setIntegrationTypes(0), // 0 = guild, 1 = user
-
-const contextExecute = async (interaction) => {
-
-        if (!interaction.isContextMenuCommand()) return;
-
-        const messageId = interaction.targetMessage.id;
-        let messageContent;
-
-        const idFilter = (i) => i.customId === `npcReplyModal-${messageId}`;
-
-        const npcReplyModal = new ModalBuilder()
-            .setCustomId(`npcReplyModal-${messageId}`)
-            .setTitle('NPC Reply')
-            .addComponents(
-                new ActionRowBuilder()
-                    .addComponents(
-                        new TextInputBuilder()
-                            .setCustomId('npcName')
-                            .setLabel('NPC Name')
-                            .setStyle(TextInputStyle.Short)
-                            .setRequired(true),
-                    ),
-                new ActionRowBuilder()
-                    .addComponents(
-                        new TextInputBuilder()
-                            .setCustomId('npcImage')
-                            .setLabel('NPC Image URL')
-                            .setStyle(TextInputStyle.Short)
-                            .setRequired(true),
-                    ),
-                new ActionRowBuilder()
-                    .addComponents(
-                        new TextInputBuilder()
-                            .setCustomId('npcDescription')
-                            .setLabel('NPC Description')
-                            .setStyle(TextInputStyle.Paragraph)
-                            .setRequired(true),
-                    ),
-            );
-
-        await interaction.showModal(npcReplyModal);
-        await interaction.reply('NPC is composing a response...');
-        await interaction.awaitModalSubmit(idFilter, { time: 15_000 })
-            .then(interaction => {
-                const npcName = modalInteraction.fields.getTextInputValue('npcName');
-                const npcImage = modalInteraction.fields.getTextInputValue('npcImage');
-                const npcDescription = modalInteraction.fields.getTextInputValue('npcDescription');
-
-
-                interaction.channel.createWebhook({
-                    name: npcName,
-                    avatar: npcImage,
-                })
-                    .then(webhook => {
-                        console.log(`Created webhook ${webhook.id} with name ${webhook.name}`);
-                        webhook.send(`i'm alive!!! my id is ${webhook.id}`);
-                    })
-                    .catch(console.error);
-            });
-    };

--- a/src/commands/npc/npcReply.js
+++ b/src/commands/npc/npcReply.js
@@ -1,0 +1,69 @@
+const { ContextMenuCommandBuilder, ApplicationCommandType, ModalBuilder, ActionRowBuilder, TextInputBuilder, TextInputStyle } = require('discord.js');
+
+module.exports = {
+    data: new ContextMenuCommandBuilder()
+        .setName('npcReply')
+        .setType(ApplicationCommandType.Message),
+        // .setDefaultMemberPermissions(PermissionFlagsBits.SendMessages)
+        // .setContexts(0) // 0 = guild, 1 = dm bot, 2 = private channel
+        // .setIntegrationTypes(0), // 0 = guild, 1 = user
+    async execute(interaction) {
+
+        if (!interaction.isContextMenuCommand()) return;
+
+        const messageId = interaction.targetMessage.id;
+        let messageContent;
+
+        const idFilter = (i) => i.customId === `npcReplyModal-${messageId}`;
+
+        const npcReplyModal = new ModalBuilder()
+            .setCustomId(`npcReplyModal-${messageId}`)
+            .setTitle('NPC Reply')
+            .addComponents(
+                new ActionRowBuilder()
+                    .addComponents(
+                        new TextInputBuilder()
+                            .setCustomId('npcName')
+                            .setLabel('NPC Name')
+                            .setStyle(TextInputStyle.Short)
+                            .setRequired(true),
+                    ),
+                new ActionRowBuilder()
+                    .addComponents(
+                        new TextInputBuilder()
+                            .setCustomId('npcImage')
+                            .setLabel('NPC Image URL')
+                            .setStyle(TextInputStyle.Short)
+                            .setRequired(true),
+                    ),
+                new ActionRowBuilder()
+                    .addComponents(
+                        new TextInputBuilder()
+                            .setCustomId('npcDescription')
+                            .setLabel('NPC Description')
+                            .setStyle(TextInputStyle.Paragraph)
+                            .setRequired(true),
+                    ),
+            );
+
+        await interaction.showModal(npcReplyModal);
+        await interaction.reply('NPC is composing a response...');
+        await interaction.awaitModalSubmit(idFilter, { time: 15_000 })
+            .then(interaction => {
+                const npcName = modalInteraction.fields.getTextInputValue('npcName');
+                const npcImage = modalInteraction.fields.getTextInputValue('npcImage');
+                const npcDescription = modalInteraction.fields.getTextInputValue('npcDescription');
+
+
+                interaction.channel.createWebhook({
+                    name: npcName,
+                    avatar: npcImage,
+                })
+                    .then(webhook => {
+                        console.log(`Created webhook ${webhook.id} with name ${webhook.name}`);
+                        webhook.send(`i'm alive!!! my id is ${webhook.id}`);
+                    })
+                    .catch(console.error);
+            });
+    },
+};

--- a/src/commands/npc/npcReply.js
+++ b/src/commands/npc/npcReply.js
@@ -1,13 +1,47 @@
-const { ContextMenuCommandBuilder, ApplicationCommandType, ModalBuilder, ActionRowBuilder, TextInputBuilder, TextInputStyle } = require('discord.js');
+const { ContextMenuCommandBuilder, ApplicationCommandType, ModalBuilder,
+    ActionRowBuilder, TextInputBuilder, TextInputStyle, SlashCommandBuilder,
+    MessageFlags } = require('discord.js');
 
 module.exports = {
-    data: new ContextMenuCommandBuilder()
+    data: new SlashCommandBuilder()
+        .setName('npcreply')
+        .setDescription('Reply as an NPC that you created')
+        .addStringOption(option =>
+            option.setName('npcname')
+                .setDescription('Enter the name of the NPC you want to reply as')
+                .setRequired(true))
+        .addStringOption(option =>
+            option.setName('message')
+                .setDescription('Enter the message you want to reply')
+                .setRequired(true))
+        .addStringOption(option =>
+            option.setName('messagelink')
+                .setDescription('Paste the id of a message here to reply it')
+                .setRequired(false)),
+    async execute(interaction) {
+
+        await interaction.reply({ content: 'Sending...', flags: MessageFlags.Ephemeral });
+
+        const channel = interaction.channel;
+        const messageId = interaction.options.getString('messagelink');
+        const message = await channel.messages.fetch(messageId)
+            .catch(console.error);
+
+        // why are we not replying to the message?
+        await message.reply(`${interaction.options.getString('npcname')}: ${interaction.options.getString('message')}`)
+        .catch(console.error);
+        await interaction.editReply({ content: 'Sent!', flags: MessageFlags.Ephemeral });
+    },
+};
+
+const contextCommand = new ContextMenuCommandBuilder()
         .setName('npcReply')
-        .setType(ApplicationCommandType.Message),
+        .setType(ApplicationCommandType.Message);
         // .setDefaultMemberPermissions(PermissionFlagsBits.SendMessages)
         // .setContexts(0) // 0 = guild, 1 = dm bot, 2 = private channel
         // .setIntegrationTypes(0), // 0 = guild, 1 = user
-    async execute(interaction) {
+
+const contextExecute = async (interaction) => {
 
         if (!interaction.isContextMenuCommand()) return;
 
@@ -65,5 +99,4 @@ module.exports = {
                     })
                     .catch(console.error);
             });
-    },
-};
+    };

--- a/src/events/commandListener.js
+++ b/src/events/commandListener.js
@@ -6,6 +6,23 @@ module.exports = {
 	trigger: Events.InteractionCreate,
 	async execute(interaction) {
 
+		if (interaction.isAutocomplete()) {
+
+			const command = interaction.client.commands.get(interaction.commandName);
+
+			if (!command?.autocomplete) {
+				console.error(`No autocomplete function found for command: ${interaction.commandName}`);
+				return;
+			}
+
+			try {
+				await command.autocomplete(interaction);
+			}
+			catch (error) {
+				console.error(error);
+			}
+		}
+
 		if (!interaction.isChatInputCommand()) return;
 
 		console.log(`[INFO]: Command triggered: ${interaction.commandName}, User: ${interaction.user.tag}, Channel: ${interaction.channel.name}`);
@@ -44,6 +61,7 @@ module.exports = {
 		setTimeout(() => timestamps.delete(interaction.user.id), cooldownAmount);
 
 		try {
+			// TODO: structure for subcommands?
 			await command.execute(interaction);
 		}
 		catch (error) {

--- a/src/events/contextMenuListener.js
+++ b/src/events/contextMenuListener.js
@@ -1,0 +1,32 @@
+const { Events } = require('discord.js');
+
+module.exports = {
+    trigger: Events.InteractionCreate,
+    async execute(interaction) {
+        // Check if the interaction is a context menu command
+        if (!interaction.isContextMenuCommand()) return;
+
+        // Check if the command is registered
+        const command = interaction.client.commands.get(interaction.commandName);
+        if (!command) {
+            console.error(`No command matching ${interaction.commandName} was found.`);
+            return;
+        }
+
+        // this does not have a cooldown yet
+
+        try {
+            console.log('Processing context menu command...');
+            await command.execute(interaction);
+        }
+        catch (error) {
+            console.error(error);
+            if (interaction.replied || interaction.deferred) {
+                await interaction.followUp({ content: 'Oops, an error occurred while executing this command!', ephemeral: true });
+            }
+            else {
+                await interaction.reply({ content: 'Uhhhh...what did you need? *(There was an error while executing this command)*', ephemeral: true });
+            }
+        }
+    },
+};

--- a/src/events/npcCreateListener.js
+++ b/src/events/npcCreateListener.js
@@ -1,0 +1,27 @@
+const { Events, MessageFlags } = require('discord.js');
+
+// processes and executes the NPC creation modal
+module.exports = {
+    trigger: Events.InteractionCreate,
+    async execute(interaction) {
+        if (!interaction.isModalSubmit()) return;
+
+        if (interaction.customId === 'createNpcModal') {
+            const npcName = interaction.fields.getTextInputValue('npcName');
+            const npcImage = interaction.fields.getTextInputValue('npcImage');
+            const npcDescription = interaction.fields.getTextInputValue('npcDescription');
+
+            await interaction.reply({ content: `NPC Created: ${npcName} - ${npcImage} - ${npcDescription}`, flags: MessageFlags.Ephemeral });
+
+            interaction.channel.createWebhook({
+                name: npcName,
+                avatar: npcImage,
+            })
+                .then(webhook => {
+                    console.log(`Created webhook ${webhook.id} with name ${webhook.name}`);
+                    webhook.send(`i'm alive!!! my id is ${webhook.id}`);
+                })
+                .catch(console.error);
+        }
+    },
+};

--- a/src/events/npcReplyListener.js
+++ b/src/events/npcReplyListener.js
@@ -1,0 +1,28 @@
+const { Events, MessageFlags } = require('discord.js');
+
+// processes and executes the NPC creation modal
+module.exports = {
+    trigger: Events.InteractionCreate,
+    async execute(interaction) {
+        if (!interaction.isModalSubmit()) return;
+
+        // custom id has a limit of 100 characters
+        if (interaction.customId.startsWith('npcReplyModal')) {
+            const npcName = interaction.fields.getTextInputValue('npcName');
+            const npcImage = interaction.fields.getTextInputValue('npcImage');
+            const npcDescription = interaction.fields.getTextInputValue('npcDescription');
+
+            await interaction.reply({ content: `NPC Created: ${npcName} - ${npcImage} - ${npcDescription}`, flags: MessageFlags.Ephemeral });
+
+            interaction.channel.createWebhook({
+                name: npcName,
+                avatar: npcImage,
+            })
+                .then(webhook => {
+                    console.log(`Created webhook ${webhook.id} with name ${webhook.name}`);
+                    webhook.send(`i'm alive!!! my id is ${webhook.id}`);
+                })
+                .catch(console.error);
+        }
+    },
+};

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ const client = new Client({
     presence: {
         activities: [{
             name: 'League of Legends',
-            type: Presence.ActivityType.Playing,
+            type: 0,
         }],
         status: 'online',
     },


### PR DESCRIPTION
basic functionality to create a webhook that functions as an NPC (non-player charcter)
- npccreate to open a modal menu to input details
- modal submit listener, which for now only listens for npc creation
- npcreply with autocomplete for available NPC names in the corresponding channel
- opens creation prompt in DMs