### PR TITLE
NPC Reply enhancement + other tidbits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "chalk": "^4.1.2",
         "discord.js": "^14.14.1",
-        "dotenv": "^16.4.5"
+        "dotenv": "^16.4.5",
+        "mongoose": "^8.15.1"
       },
       "devDependencies": {
         "eslint": "^8.57.0"
@@ -245,6 +246,15 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.2.2.tgz",
+      "integrity": "sha512-EB0O3SCSNRUFk66iRCpI+cXzIjdswfCs7F6nOC3RAGJ7xr5YhaicvsRwJ9eyzYvYRlCSDUO/c7g4yNulxKC1WA==",
+      "license": "MIT",
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -323,6 +333,21 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
       }
     },
     "node_modules/@types/ws": {
@@ -441,6 +466,15 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/bson": {
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
+      "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.20.1"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -511,7 +545,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1043,6 +1076,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/kareem": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.6.3.tgz",
+      "integrity": "sha512-C3iHfuGUXK2u8/ipq9LfjFfXFxAZMQJJq7vLS45r3D9Y2xQ/m4S8zaR4zMLFWh9AsNPXmcFfUDhTEO8UIC/V6Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -1108,6 +1150,12 @@
       "integrity": "sha512-ThQLOhN86ZkJ7qemtVRGYM+gRgR8GEXNli9H/PMvpnZsE44Xfh3wx9kGJaldg314v85m+bFW6WBMaVHJc/c3zA==",
       "license": "MIT"
     },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "license": "MIT"
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -1121,11 +1169,109 @@
         "node": "*"
       }
     },
+    "node_modules/mongodb": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.16.0.tgz",
+      "integrity": "sha512-D1PNcdT0y4Grhou5Zi/qgipZOYeWrhLEpk33n3nm6LGtz61jvO88WlrWCK/bigMjpnOdAUKKQwsGIl0NtWMyYw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.1.9",
+        "bson": "^6.10.3",
+        "mongodb-connection-string-url": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.2.2",
+        "socks": "^2.7.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
+      "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/whatwg-url": "^11.0.2",
+        "whatwg-url": "^14.1.0 || ^13.0.0"
+      }
+    },
+    "node_modules/mongoose": {
+      "version": "8.15.1",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.15.1.tgz",
+      "integrity": "sha512-RhQ4DzmBi5BNGcS0w4u1vdMRIKcteXTCNzDt1j7XRcdWYBz1MjMjulBhPaeC5jBCHOD1yinuOFTTSOWLLGexWw==",
+      "license": "MIT",
+      "dependencies": {
+        "bson": "^6.10.3",
+        "kareem": "2.6.3",
+        "mongodb": "~6.16.0",
+        "mpath": "0.9.0",
+        "mquery": "5.0.0",
+        "ms": "2.1.3",
+        "sift": "17.1.3"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mongoose"
+      }
+    },
+    "node_modules/mpath": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
+      "integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mquery": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-5.0.0.tgz",
+      "integrity": "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4.x"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/natural-compare": {
@@ -1252,7 +1398,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -1364,6 +1509,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/sift": {
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-17.1.3.tgz",
+      "integrity": "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==",
+      "license": "MIT"
+    },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "memory-pager": "^1.0.2"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -1408,6 +1568,18 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/ts-mixer": {
       "version": "6.0.4",
@@ -1470,6 +1642,28 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "dependencies": {
     "chalk": "^4.1.2",
     "discord.js": "^14.14.1",
-    "dotenv": "^16.4.5"
+    "dotenv": "^16.4.5",
+    "mongoose": "^8.15.1"
   },
   "devDependencies": {
     "eslint": "^8.57.0"

--- a/src/commands/npc/npcCreate.js
+++ b/src/commands/npc/npcCreate.js
@@ -1,16 +1,14 @@
 // using modals and webhooks to create a new NPC for discord messaging
-const { ActionRowBuilder, ModalBuilder, TextInputBuilder, TextInputStyle, SlashCommandBuilder } = require('discord.js');
+const { ActionRowBuilder, ModalBuilder, TextInputBuilder, TextInputStyle, SlashCommandBuilder, PermissionsBitField } = require('discord.js');
 
 module.exports = {
     cooldown: 5,
     data: new SlashCommandBuilder()
         .setName('createnpc')
-        .setDescription('Creates a new NPC for the server'),
+        .setDescription('Launches a modal to create a new NPC')
+        .setDefaultMemberPermissions(PermissionsBitField.ManageWebhooks), // requires Manage Webhooks permission
 
     async execute(interaction) {
-        // TODO configure required role
-
-        // TODO create a modal to get the NPC name and description
         const modal = new ModalBuilder()
             .setCustomId('createNpcModal')
             .setTitle('Create a new NPC');

--- a/src/commands/npc/npcReply.js
+++ b/src/commands/npc/npcReply.js
@@ -1,4 +1,11 @@
-const { SlashCommandBuilder, MessageFlags, ContainerBuilder, ComponentType, TextDisplayBuilder } = require('discord.js');
+const { SlashCommandBuilder, MessageFlags, ContainerBuilder, ButtonBuilder, ActionRowBuilder, ComponentType, TextDisplayBuilder } = require('discord.js');
+
+const CANCEL_PRESSED = 'cancelled';
+const FINISH_PRESSED = 'finished';
+
+const messages = [];
+let messageCollector;
+let buttonCollector;
 
 module.exports = {
     cooldown: 300,
@@ -18,84 +25,38 @@ module.exports = {
 
     async execute(interaction) {
 
-        const client = interaction.client;
         const npcId = interaction.options.getString('npcname');
         const messageId = interaction.options.getString('messagelink');
         const base_channel = interaction.channel;
 
-        // validate inputs
-        let webhook;
-        try {
+        const [webhook, dmChannel, targetMessage] = await validateInputs(interaction, npcId, messageId, base_channel);
 
-            // Fetch the webhooks for the channel
-            webhook = await client.fetchWebhook(npcId);
-            // Find the webhook with the matching name
+        const prompt = new TextDisplayBuilder()
+            .setContent(
+                targetMessage ? `## ${webhook.name} will reply...` : `## ${webhook.name} will send...`,
+            );
 
-            if (!webhook) {
-                console.error(`No webhook found for NPC: ${npcId}`);
-                await interaction.reply({ content: `No webhook found for NPC: ${npcId}`, flags: MessageFlags.Ephemeral });
-                return;
-            }
-        }
-        catch (err) {
-            console.error('Error fetching webhook:', err);
-            await interaction.reply({ content: 'Error fetching webhooks. Please try again later.', flags: MessageFlags.Ephemeral });
-            return;
-        }
+        const instructions = new TextDisplayBuilder()
+            .setContent('-# Type messages in this channel to add to the reply');
 
-        let targetMessage;
-        if (messageId) {
-            try {
-                // Fetch the message to reply to
-                targetMessage = await base_channel.messages.fetch(messageId);
-            }
-            catch (err) {
-                console.error('Error fetching message:', err);
-                await interaction.reply({ content: 'Could not find the message to reply to. Please check the message ID.', flags: MessageFlags.Ephemeral });
-                return;
-            }
-        }
+        const finishButton = new ButtonBuilder()
+            .setCustomId('finish')
+            .setLabel('Finish')
+            .setStyle(1); // Primary style
 
-        // Try to DM the user
-        let dmChannel;
-        try {
-            dmChannel = await interaction.user.createDM();
-        }
-        catch (err) {
-            console.error('Could not create DM channel:', err);
-            await interaction.reply({ content: 'Could not send you a DM! Please check your server privacy settings to allow Direct Messages.', flags: MessageFlags.Ephemeral });
-            return;
-        }
+        const cancelButton = new ButtonBuilder()
+            .setCustomId('cancel')
+            .setLabel('Cancel')
+            .setStyle(2); // Secondary style
 
-        console.log(`Validated inputs: Webhook ID: ${npcId}, Message ID: ${messageId}, DM Channel: ${dmChannel.id}`);
+        const row = new ActionRowBuilder()
+            .addComponents(finishButton, cancelButton);
 
         // create a container builder
-        const messages = [];
-        const container = new ContainerBuilder({
-            components: [
-                {
-                    content: '-# Type messages in this channel to add to the reply',
-                    type: ComponentType.TextDisplay,
-                },
-                {
-                    type: ComponentType.ActionRow,
-                    components: [
-                        {
-                            type: ComponentType.Button,
-                            custom_id: 'finish',
-                            label: 'Finish',
-                            style: 1, // Primary style
-                        },
-                        {
-                            type: ComponentType.Button,
-                            custom_id: 'cancel',
-                            label: 'Cancel',
-                            style: 2, // Secondary style
-                        },
-                    ],
-                },
-            ],
-        });
+        const container = new ContainerBuilder()
+            .addTextDisplayComponents(prompt, instructions)
+            .addActionRowComponents(row);
+
 
         // send the initial container
         const containerMsg = await dmChannel.send({ components: [container], flags: MessageFlags.IsComponentsV2 })
@@ -108,77 +69,37 @@ module.exports = {
         await interaction.reply({ content: `Check your DMs to reply as ${webhook.name}!`, flags: MessageFlags.Ephemeral });
 
         // set up collectors for messages and button interactions
-        const messageFilter = m => m.author.id === interaction.user.id;
-        const messageCollector = dmChannel.createMessageCollector({
+        const messageFilter = m => m.author.id === interaction.user.id; // this will block messages from the bot itself
+        messageCollector = dmChannel.createMessageCollector({
             filter: messageFilter,
-            idle: 120_000, // 2 minute idle time
-            time: 300_000, // 5 minutes total time
+            idle: 120_000,
+            time: 300_000,
         });
 
-        const buttonCollector = containerMsg.createMessageComponentCollector({
+        buttonCollector = containerMsg.createMessageComponentCollector({
             componentType: ComponentType.Button,
-            idle: 120_000, // 2 minute idle time
-            time: 300_000, // 5 minutes total time
+            idle: 180_000,
+            time: 300_000,
         });
 
         messageCollector.on('collect', async (message) => {
-            let newComponent = {
-                content: `${message.content}`,
-                type: ComponentType.TextDisplay,
-            };
-            messages.push(message.content);
-
-            container.spliceComponents(
-                container.components.length - 1,
-                {
-                    content: `${message.content}`,
-                    type: ComponentType.TextDisplay,
-                },
-            );
-
-            await containerMsg.edit({ components: [container], flags: MessageFlags.IsComponentsV2 });
-
-            console.log(`Collected message: ${message.content}`);
+            pushNewMessage(message, container, containerMsg);
         });
 
-        /*
-        messageCollector.on('dispose', (message) => {
-            if (message.content.toLowerCase().startsWith('cancel') || message.content.toLowerCase().startsWith('finish')) {
-                messageCollector.stop('cancelled');
-                console.log('Message collection cancelled by user.');
-                return;
-            }
-            console.error('Message was disposed');
-            return;
-        });
-        */
-
-        messageCollector.on('end', async (collected) => {
-            await dmChannel.send(`Message collection ended. Collected ${collected.size} messages`);
-        });
-
-        // at some point, this will need additional confirmation
         buttonCollector.on('collect', async (buttonInteraction) => {
-            if (buttonInteraction.customId === 'finish') {
-                // send the reply using the webhook
-                try {
-                    await webhook.send({
-                        content: messages.join('\n'),
-                        allowedMentions: { parse: [] }, // prevent mentions
-                        flags: MessageFlags.SuppressEmbeds,
-                    });
-                    messageCollector.stop('finished');
-                    await buttonInteraction.reply({ content: 'Reply sent successfully!' });
-                }
-                catch (err) {
-                    console.error('Error sending webhook message:', err);
-                    await buttonInteraction.reply({ content: 'Failed to send reply.', flags: MessageFlags.Ephemeral });
-                }
-            }
-            else if (buttonInteraction.customId === 'cancel') {
-                await buttonInteraction.reply({ content: 'Reply cancelled.' });
-                messageCollector.stop('cancelled');
-            }
+            await handleButtonInteraction(buttonInteraction, webhook, messageCollector);
+        });
+
+        // notify the user that the collection has ended
+        messageCollector.on('end', async (collected, reason) => { await handleMessageCollectorClose(collected, reason, dmChannel); });
+
+        // visually update the buttons when the collector ends
+        buttonCollector.on('end', async (collected, reason) => {
+            console.log(`Button collector ended for reason: ${reason}`);
+            finishButton.setDisabled(true);
+            cancelButton.setDisabled(true);
+            row.setComponents(finishButton, cancelButton);
+            await containerMsg.edit({ components: [container], flags: MessageFlags.IsComponentsV2 });
         });
 
     },
@@ -199,3 +120,129 @@ module.exports = {
         );
     },
 };
+
+async function pushNewMessage(message, container, containerMsg) {
+    const newComponent = {
+        content: `${message.content}`,
+        type: ComponentType.TextDisplay,
+    };
+
+    // insert in container and update the messages array
+    container.spliceComponents(2 + messages.length, 0, newComponent);
+    messages.push(message.content);
+
+    await containerMsg.edit({ components: [container], flags: MessageFlags.IsComponentsV2 });
+
+    console.log(`Collected message: ${message.content}`);
+}
+
+async function handleButtonInteraction(buttonInteraction, webhook) {
+    if (buttonInteraction.customId === 'finish') {
+        // send the reply using the webhook
+        if (messages.length === 0) {
+            await buttonInteraction.channel.send('You can\'t send an empty reply. Please type a message first.');
+            return;
+        }
+
+        try {
+            await webhook.send({
+                content: messages.join('\n'),
+                allowedMentions: { parse: [] }, // prevent mentions
+                flags: MessageFlags.SuppressEmbeds,
+            });
+            await buttonInteraction.reply({ content: 'Reply sent successfully!' });
+            messageCollector.stop(FINISH_PRESSED);
+            buttonCollector.stop(FINISH_PRESSED);
+        }
+        catch (err) {
+            console.error('Error sending webhook message:', err);
+            await buttonInteraction.reply({ content: 'An error occurred, failed to send reply.', flags: MessageFlags.Ephemeral });
+        }
+    }
+    else if (buttonInteraction.customId === 'cancel') {
+        await buttonInteraction.reply({ content: 'Reply cancelled.' });
+        messageCollector.stop(CANCEL_PRESSED);
+        buttonCollector.stop(CANCEL_PRESSED);
+    }
+}
+
+/**
+ * Contains the logic for notifying the user when the message collector shuts off. The output changes depending on whether any messages were collected.
+ * @param {ReadonlyCollection<Snowflake, Message>} collected - A collection of messages from the user, given by the collector on the end event.
+ * @param {DMChannel} dmChannel - The DM channel where the user is sending messages.
+ * @param {MessageComponentCollector} buttonCollector - A reference to the container's button collector, so that it can be stopped if no messages were collected.
+ * @returns {void} - This function does not return anything, but it sends a message to the user in the DM channel.
+ */
+async function handleMessageCollectorClose(collected, reason, dmChannel) {
+    if (reason === FINISH_PRESSED || reason === CANCEL_PRESSED) {
+        console.log(`Message collector ended for reason: ${reason}`);
+    }
+    else if (collected.size === 0) {
+        await dmChannel.send('Didn\'t get your message, maybe next time.');
+        buttonCollector.stop('no messages');
+        return;
+    }
+    else {
+        await dmChannel.send('I stopped paying attention, but I still have your messages. Use the container buttons to finish or cancel your reply.');
+    }
+}
+
+/**
+ * Validates the inputs for the NPC reply command before sending the container. If there is an error, it replies to the interaction with an error message in the channel the command was made in.
+ * @param {Interaction} interaction - the interaction object from discord.js
+ * @param {Snowflake} npcId - the ID of the NPC webhook to reply as
+ * @param {Snowflake} [messageId] - the ID of the message to reply to, if specified
+ * @returns { [Webhook, Channel, Message] } Successful validation returns an object with the webhook, the dm's channel, and the message to reply to, if specified.
+ */
+async function validateInputs(interaction, npcId, messageId) {
+
+    const client = interaction.client;
+    const base_channel = interaction.channel;
+
+    // validate inputs
+    let webhook;
+    try {
+
+        // Fetch the webhooks for the channel
+        webhook = await client.fetchWebhook(npcId);
+        // Find the webhook with the matching name
+
+        if (!webhook) {
+            console.error(`No webhook found for NPC: ${npcId}`);
+            await interaction.reply({ content: `No webhook found for with an ID of ${npcId}. Make sure the webhook still exists and use the autocomplete result.`, flags: MessageFlags.Ephemeral });
+            return;
+        }
+    }
+    catch (err) {
+        console.error('Error fetching webhook:', err);
+        await interaction.reply({ content: 'Error fetching webhooks. Please try again later.', flags: MessageFlags.Ephemeral });
+        return;
+    }
+
+    // Try to DM the user
+    let dmChannel;
+    try {
+        dmChannel = await interaction.user.createDM();
+    }
+    catch (err) {
+        console.error('Could not create DM channel:', err);
+        await interaction.reply({ content: 'Could not send you a DM! Please check your server privacy settings to allow Direct Messages.', flags: MessageFlags.Ephemeral });
+        return;
+    }
+
+    // If a message ID is provided, fetch the message to reply to
+    let targetMessage;
+    if (messageId) {
+        try {
+            // Fetch the message to reply to
+            targetMessage = await base_channel.messages.fetch(messageId);
+        }
+        catch (err) {
+            console.error('Error fetching message:', err);
+            await interaction.reply({ content: 'Could not find the message you want reply to. Please double check the message ID.', flags: MessageFlags.Ephemeral });
+            return;
+        }
+    }
+
+    return [ webhook, dmChannel, targetMessage ];
+}

--- a/src/commands/npc/npcReply.js
+++ b/src/commands/npc/npcReply.js
@@ -1,6 +1,8 @@
 const { SlashCommandBuilder, MessageFlags, ContainerBuilder, ComponentType, TextDisplayBuilder } = require('discord.js');
 
 module.exports = {
+    cooldown: 300,
+    reason: 'Please finish your current reply before starting a new one.',
     data: new SlashCommandBuilder()
         .setName('npcreply')
         .setDescription('Reply as an NPC that you created')

--- a/src/commands/npc/npcReply.js
+++ b/src/commands/npc/npcReply.js
@@ -106,9 +106,9 @@ module.exports = {
         await interaction.reply({ content: `Check your DMs to reply as ${webhook.name}!`, flags: MessageFlags.Ephemeral });
 
         // set up collectors for messages and button interactions
-        // const messageFilter = m => !m.content.startsWith('cancel') || !m.content.startsWith('finish');
+        const messageFilter = m => m.author.id === interaction.user.id;
         const messageCollector = dmChannel.createMessageCollector({
-            // filter: messageFilter,
+            filter: messageFilter,
             idle: 120_000, // 2 minute idle time
             time: 300_000, // 5 minutes total time
         });

--- a/src/commands/utility/private/reload.js
+++ b/src/commands/utility/private/reload.js
@@ -19,13 +19,13 @@ module.exports = {
         delete require.cache[require.resolve(`./${command.data.name}.js`)];
 
         try {
-            interaction.client.commands.delete(command.data.name);
             const newCmd = require(`./${command.data.name}.js`);
             interaction.client.commands.set(newCmd.data.name, newCmd);
             await interaction.reply(`Command \`${newCmd.data.name}\` was reloaded.`);
-        } catch (error) {
+        }
+        catch (error) {
             console.error(error);
-            await interaction.reply(`Error while reloading command \`${newCmd.data.name}\`.\n\`${error.message}\``);
+            await interaction.reply(`Error while reloading command \`${command.data.name}\`.\n\`${error.message}\``);
         }
     },
 };

--- a/src/commands/utility/settings.js
+++ b/src/commands/utility/settings.js
@@ -1,0 +1,1 @@
+// todo: figure out how settings will work

--- a/src/events/commandListener.js
+++ b/src/events/commandListener.js
@@ -1,5 +1,5 @@
 const { Collection } = require('@discordjs/collection');
-const { Events } = require('discord.js');
+const { Events, MessageFlags } = require('discord.js');
 
 // processes and executes Chat Input Commands
 module.exports = {
@@ -67,10 +67,10 @@ module.exports = {
 		catch (error) {
 			console.error(error);
 			if (interaction.replied || interaction.deferred) {
-				await interaction.followUp({ content: 'There was an error while executing this command!', ephemeral: true });
+				await interaction.followUp({ content: 'There was an error while executing this command!', flags: MessageFlags.Ephemeral });
 			}
 			else {
-				await interaction.reply({ content: 'There was an error while executing this command!', ephemeral: true });
+				await interaction.reply({ content: 'There was an error while executing this command!', flags: MessageFlags.Ephemeral });
 			}
 		}
 	},

--- a/src/events/commandListener.js
+++ b/src/events/commandListener.js
@@ -52,7 +52,13 @@ module.exports = {
 			const expireTime = timestamps.get(interaction.user.id) + cooldownAmount;
 			if (now < expireTime) {
 				const expiredTimestamp = Math.round(expireTime / 1_000);
-				return interaction.reply({ content: `Please wait, you are still on cooldown until \`${expiredTimestamp}\`` });
+
+				if (command?.reason) {
+					return interaction.reply({ content: command.reason, flags: MessageFlags.Ephemeral });
+				}
+				else {
+					return interaction.reply({ content: `Please wait, you are still on cooldown until \`${expiredTimestamp}\``, flags: MessageFlags.Ephemeral });
+				}
 			}
 			return interaction.reply('Still on cooldown!');
 		}

--- a/src/events/npcCreateListener.js
+++ b/src/events/npcCreateListener.js
@@ -16,6 +16,7 @@ module.exports = {
             interaction.channel.createWebhook({
                 name: npcName,
                 avatar: npcImage,
+                reason: `Created by ${interaction.user.tag}`,
             })
                 .then(webhook => {
                     console.log(`Created webhook ${webhook.id} with name ${webhook.name}`);

--- a/src/events/ready.js
+++ b/src/events/ready.js
@@ -1,5 +1,5 @@
 const { Events } = require('discord.js');
-const { chalk } = require('chalk');
+const chalk = require('chalk');
 module.exports = {
 	trigger: Events.ClientReady,
 	once: true,

--- a/src/events/ready.js
+++ b/src/events/ready.js
@@ -1,9 +1,9 @@
 const { Events } = require('discord.js');
-
+const { chalk } = require('chalk');
 module.exports = {
 	trigger: Events.ClientReady,
 	once: true,
 	execute(client) {
-		console.log(`Ready! Logged in as ${client.user.tag}`);
+		console.log(chalk.green(`Ready! Logged in as ${client.user.tag}`));
 	},
 };

--- a/src/events/serverJoin.js
+++ b/src/events/serverJoin.js
@@ -1,0 +1,1 @@
+// todo initialize things on server join

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,11 @@
+const { chalk } = require('chalk');
+console.log(chalk.blue('Initializing AyyyyyyBot...'));
+
 const fs = require('node:fs');
 const path = require('node:path');
 const { Client, Collection, GatewayIntentBits } = require('discord.js');
 require('dotenv').config(); // .env file accessed with process.env
+
 
 // new client instance
 const client = new Client({
@@ -17,6 +21,16 @@ const client = new Client({
 
 client.commands = new Collection(); // extended map
 client.cooldowns = new Collection();
+console.log(chalk.green('Client initialized.\n'));
+
+const mongoose = require('mongoose');
+try {
+    mongoose.connect(process.env.MONGO_URI);
+    console.log(chalk.green('Database connected.'));
+}
+catch (err) {
+    console.error('Error connecting to MongoDB:', err);
+}
 
 // load commands
 console.log('Reviewing commands...\n');
@@ -38,14 +52,14 @@ for (const folder of commandFolders) {
             client.commands.set(command.data.name, command);
         }
         else {
-            console.log(`[WARNING] The command at ${filePath} is missing a required "data" or "execute" property.`);
+            console.log(chalk.yellow('[WARNING]'), `The command at ${filePath} is missing a required "data" or "execute" property.`);
         }
     }
 }
 
 // should files be labeled as command- and event-?
 // load event listener files
-console.log('Tuning into event listeners...\n');
+console.log('Tuning into event listeners...');
 const eventsPath = path.join(__dirname, 'events');
 const eventFiles = fs.readdirSync(eventsPath).filter(file => file.endsWith('.js'));
 
@@ -63,5 +77,6 @@ for (const file of eventFiles) {
 	}
 }
 
+console.log(chalk.green('Done.\n'));
 // login using token
 client.login(process.env.BOT_TOKEN);

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-const { chalk } = require('chalk');
+const chalk = require('chalk');
 console.log(chalk.blue('Initializing AyyyyyyBot...'));
 
 const fs = require('node:fs');
@@ -24,13 +24,8 @@ client.cooldowns = new Collection();
 console.log(chalk.green('Client initialized.\n'));
 
 const mongoose = require('mongoose');
-try {
-    mongoose.connect(process.env.MONGO_URI);
-    console.log(chalk.green('Database connected.'));
-}
-catch (err) {
-    console.error('Error connecting to MongoDB:', err);
-}
+mongoose.connect(process.env.MONGO_URI)
+    .catch(err => console.error(chalk.red('Database connection error:', err)));
 
 // load commands
 console.log('Reviewing commands...\n');
@@ -77,6 +72,9 @@ for (const file of eventFiles) {
 	}
 }
 
-console.log(chalk.green('Done.\n'));
+mongoose.connection.on('error', err => console.error(chalk.red('Database connection error:', err)));
+mongoose.connection.on('disconnected', () => console.log(chalk.yellow('Database disconnected.')));
+mongoose.connection.on('connected', () => console.log(chalk.green('Database connected.')));
+
 // login using token
 client.login(process.env.BOT_TOKEN);

--- a/src/npc-schema.js
+++ b/src/npc-schema.js
@@ -1,0 +1,18 @@
+const mongoose = require('mongoose');
+const { Schema } = mongoose;
+
+const npcSchema = new Schema({
+    name: String,
+    id: String,
+    image: String,
+});
+
+const serverSchema = new Schema({
+    serverId: String,
+    npcs: [npcSchema], // Array of NPCs for each server
+});
+
+const Npc = mongoose.model('NPC', npcSchema);
+
+module.exports = Npc;
+module.exports.npcSchema = npcSchema;


### PR DESCRIPTION
Contains a few changes to existing scripts & functions. This was originally intended to add database functionality, but turned into a rabbit hole on making the NPC module function.

# Changelog
## NPC Module
- Interacting with the NPC commands now requires the `manage_webhooks` permission. This can be changed to be a custom role check once needed.
- The reply file was reorganized to have more organized logic in functions. 

## General
- Added an ability to give a custom message if a command is on cooldown. 
- Startup logging has been made more colorful.
- `mongoose` was added and connects to a database on the local machine. This does not break functionality if the database is not present, as nothing relies on it yet. Arguably I should not include this.

## Future notes
- Database hookup exists, but does nothing. 
- A fix needs to happen for the reload script